### PR TITLE
Spring Security JWT Filter 로직 수정 및 Controller 임시 UserId 파라미터 제거

### DIFF
--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/config/filter/JwtFilter.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/config/filter/JwtFilter.java
@@ -2,9 +2,7 @@ package com.triplem.momoim.auth.config.filter;
 
 import com.triplem.momoim.auth.AuthUser;
 import com.triplem.momoim.auth.config.UserAuthentication;
-import com.triplem.momoim.auth.jwt.JwtProvider;
 import com.triplem.momoim.auth.jwt.JwtResolver;
-import com.triplem.momoim.auth.utils.StaticEndpointChecker;
 import com.triplem.momoim.exception.BusinessException;
 import com.triplem.momoim.exception.ExceptionCode;
 import jakarta.annotation.Nonnull;
@@ -12,75 +10,49 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
     private static final String PREFIX_BEARER = "Bearer ";
     private static final String PREFIX_AUTHORIZATION = "Authorization";
-    private static final String PREFIX_UN_AUTHORIZATION = "UnAuthorization";
-
     private static final String CONTENT_TYPE = "application/json;charset=UTF-8";
     private static final String RESPONSE_CODE_KEY = "code";
     private static final String RESPONSE_MESSAGE_KEY = "message";
 
-//    private static final List<String> whiteListPatterns = List.of(
-//            "/swagger-ui/**",
-//            "/api-docs/**",
-//            "/api/v1/token/**"
-//    );
-
-    private final JwtProvider jwtProvider;
     private final JwtResolver jwtResolver;
-
-    private final StaticEndpointChecker endpointChecker;
-    private final List<String> whiteListPatterns;
-    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     @Override
     protected void doFilterInternal(
-            @Nonnull HttpServletRequest request,
-            @Nonnull HttpServletResponse response,
-            @Nonnull FilterChain filterChain
+        @Nonnull HttpServletRequest request,
+        @Nonnull HttpServletResponse response,
+        @Nonnull FilterChain filterChain
     ) throws ServletException, IOException {
-//        if (isWhiteListRequest(request) || endpointChecker.isEndpointNotExist(request)) {
-//            filterChain.doFilter(request, response);
-//            return;
-//        }
-
         try {
             String jwt = getJwtFromRequest(request);
             AuthUser authUser = jwtResolver.resolveAccessToken(jwt);
             Long userId = authUser.id();
-            UserAuthentication authentication = new UserAuthentication(userId, null);
+            UserAuthentication authentication = new UserAuthentication(userId, "USER");
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);
-            filterChain.doFilter(request, response);
-
         } catch (BusinessException e) {
-            setExceptionResponse(e.getExceptionCode(), response);
-        } catch (Exception e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 인증 정보입니다.");
+            if (e.getExceptionCode().equals(ExceptionCode.EXPIRED_JWT) || e.getExceptionCode().equals(ExceptionCode.UNKNOWN_JWT_VALIDATE_ERROR)) {
+                setExceptionResponse(e.getExceptionCode(), response);
+            }
+        } finally {
+            if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                setGuestAuthentication(request);
+            }
+            filterChain.doFilter(request, response);
         }
-    }
-
-    private String getJwtFromRequest(HttpServletRequest request) {
-        String bearerToken = request.getHeader(PREFIX_AUTHORIZATION);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX_BEARER)) {
-            return bearerToken.substring(PREFIX_BEARER.length());
-        }
-        throw new BusinessException(ExceptionCode.UNSUPPORTED_BEARER_FORMAT);
     }
 
     private void setExceptionResponse(ExceptionCode exceptionCode, HttpServletResponse response) throws IOException {
@@ -94,10 +66,17 @@ public class JwtFilter extends OncePerRequestFilter {
         response.getWriter().print(responseBody);
     }
 
-    private boolean isWhiteListRequest(HttpServletRequest request) {
-        String requestUri = request.getRequestURI();
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(PREFIX_AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX_BEARER)) {
+            return bearerToken.substring(PREFIX_BEARER.length());
+        }
+        throw new BusinessException(ExceptionCode.UNSUPPORTED_BEARER_FORMAT);
+    }
 
-        return whiteListPatterns.stream()
-                .anyMatch(pattern -> antPathMatcher.match(pattern, requestUri));
+    private void setGuestAuthentication(HttpServletRequest request) {
+        UserAuthentication authentication = new UserAuthentication(-1L, "GUEST");
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/config/filter/JwtFilter.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/config/filter/JwtFilter.java
@@ -36,6 +36,7 @@ public class JwtFilter extends OncePerRequestFilter {
         @Nonnull HttpServletResponse response,
         @Nonnull FilterChain filterChain
     ) throws ServletException, IOException {
+        boolean occurJWTException = false;
         try {
             String jwt = getJwtFromRequest(request);
             AuthUser authUser = jwtResolver.resolveAccessToken(jwt);
@@ -46,12 +47,15 @@ public class JwtFilter extends OncePerRequestFilter {
         } catch (BusinessException e) {
             if (e.getExceptionCode().equals(ExceptionCode.EXPIRED_JWT) || e.getExceptionCode().equals(ExceptionCode.UNKNOWN_JWT_VALIDATE_ERROR)) {
                 setExceptionResponse(e.getExceptionCode(), response);
+                occurJWTException = true;
             }
         } finally {
             if (SecurityContextHolder.getContext().getAuthentication() == null) {
                 setGuestAuthentication(request);
             }
-            filterChain.doFilter(request, response);
+            if (!occurJWTException) {
+                filterChain.doFilter(request, response);
+            }
         }
     }
 

--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtResolver.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtResolver.java
@@ -3,7 +3,10 @@ package com.triplem.momoim.auth.jwt;
 import com.triplem.momoim.auth.AuthUser;
 import com.triplem.momoim.exception.BusinessException;
 import com.triplem.momoim.exception.ExceptionCode;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,30 +20,27 @@ public class JwtResolver {
     }
 
     /**
-     * Internal method to parse and validate a JWT token.
-     * This method validates the token signature, structure, and expiration,
-     * and extracts claims to construct an AuthUser object.
+     * Internal method to parse and validate a JWT token. This method validates the token signature, structure, and expiration, and extracts claims to
+     * construct an AuthUser object.
      *
      * @param token the JWT token to resolve
      * @return AuthUser instance containing user details from the token
      * @throws RuntimeException for various JWT parsing and validation errors
-     *
-     * @apiNote Replace RuntimeException with CustomException and a well-defined ErrorCode enum
-     *       for better error categorization and handling.
+     * @apiNote Replace RuntimeException with CustomException and a well-defined ErrorCode enum for better error categorization and handling.
      */
     private AuthUser resolveToken(String token) {
         try {
             Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(jwtProperties.getSecretKey())
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
+                .setSigningKey(jwtProperties.getSecretKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
 
             Long userId = Long.valueOf(claims.getSubject());
             return AuthUser.from(userId);
 
         } catch (ExpiredJwtException e) {
-            throw new RuntimeException("Expired jwt exception");
+            throw new BusinessException(ExceptionCode.EXPIRED_JWT);
         } catch (JwtException e) {
             throw new BusinessException(ExceptionCode.UNKNOWN_JWT_VALIDATE_ERROR);
         }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/gathering/controller/GatheringController.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/gathering/controller/GatheringController.java
@@ -10,6 +10,7 @@ import com.triplem.momoim.api.gathering.request.RegisterGatheringRequest;
 import com.triplem.momoim.api.gathering.service.GatheringJoinService;
 import com.triplem.momoim.api.gathering.service.GatheringManagementService;
 import com.triplem.momoim.api.gathering.service.GatheringService;
+import com.triplem.momoim.auth.utils.SecurityUtil;
 import com.triplem.momoim.core.common.PaginationInformation;
 import com.triplem.momoim.core.domain.gathering.Gathering;
 import com.triplem.momoim.core.domain.gathering.GatheringCategory;
@@ -21,6 +22,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -57,26 +59,28 @@ public class GatheringController {
     }
 
     @PostMapping
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 생성", summary = "모임 생성", tags = {"gatherings"}, description = "모임 생성")
     public ApiResponse<GatheringListItem> registerGathering(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @RequestBody RegisterGatheringRequest request) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         Gathering gathering = gatheringManagementService.register(request.toGathering(userId));
         return ApiResponse.success(GatheringListItem.from(gathering));
     }
 
     @GetMapping("/joined")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "참여중인 모임 목록 조회", summary = "참여중인 모임 목록 조회", tags = {"gatherings"}, description = "참여중인 모임 목록 조회")
     public ApiResponse<List<GatheringListItem>> getMyGatherings(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "페이징 offset") @RequestParam int offset,
         @Parameter(name = "페이징 limit") @RequestParam int limit) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         List<GatheringListItem> myGatherings = gatheringService.getMyGatherings(userId, new PaginationInformation(offset, limit));
         return ApiResponse.success(myGatherings);
     }
@@ -98,8 +102,8 @@ public class GatheringController {
     })
     @Operation(operationId = "모임 상세 조회", summary = "모임 상세 조회", tags = {"gatherings"}, description = "모임 상세 조회")
     public ApiResponse<GatheringDetail> getGathering(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam(defaultValue = "-1") Long userId,
         @Parameter(name = "조회 할 모임 ID") @PathVariable Long gatheringId) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         GatheringDetail gathering = gatheringService.getGatheringDetail(gatheringId, userId);
         return ApiResponse.success(gathering);
     }
@@ -120,58 +124,63 @@ public class GatheringController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 취소", summary = "모임 취소", tags = {"gatherings"}, description = "모임 취소")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     public DefaultApiResponse cancelGathering(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @PathVariable Long gatheringId) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         gatheringManagementService.cancel(userId, gatheringId);
         return DefaultApiResponse.success();
     }
 
     @PostMapping("/{gatheringId}/join")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 참여", summary = "모임 참여", tags = {"gatherings"}, description = "모임 참여")
     public DefaultApiResponse joinGathering(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "모임 ID") @PathVariable Long gatheringId) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         gatheringJoinService.joinGathering(userId, gatheringId);
         return DefaultApiResponse.success();
     }
 
     @DeleteMapping("/{gatheringId}/leave")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 참여 취소", summary = "모임 참여 취소", tags = {"gatherings"}, description = "모임 참여 취소")
     public DefaultApiResponse leaveGathering(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "모임 ID") @PathVariable Long gatheringId) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         gatheringJoinService.cancelJoinGathering(userId, gatheringId);
         return DefaultApiResponse.success();
     }
 
     @PatchMapping("/{gatheringId}")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 수정", summary = "모임 수정", tags = {"gatherings"}, description = "모임 수정")
     public DefaultApiResponse modifyGathering(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "모임 ID") @PathVariable Long gatheringId,
         @RequestBody ModifyGatheringRequest request) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         gatheringManagementService.modify(userId, request.toContent(gatheringId));
         return DefaultApiResponse.success();
     }
 
     @DeleteMapping("/member/{gatheringMemberId}")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "멤버 추방", summary = "멤버 추방", tags = {"gatherings"}, description = "멤버 추방")
     public DefaultApiResponse kickMember(
-        @Parameter(name = "추방 할 gatheringMemberId") @PathVariable Long gatheringMemberId,
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId) {
+        @Parameter(name = "추방 할 gatheringMemberId") @PathVariable Long gatheringMemberId) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         gatheringManagementService.kickMember(userId, gatheringMemberId);
         return DefaultApiResponse.success();
     }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/review/controller/ReviewController.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.triplem.momoim.api.common.DefaultApiResponse;
 import com.triplem.momoim.api.review.request.ModifyReviewRequest;
 import com.triplem.momoim.api.review.request.RegisterReviewRequest;
 import com.triplem.momoim.api.review.service.ReviewService;
+import com.triplem.momoim.auth.utils.SecurityUtil;
 import com.triplem.momoim.core.common.PaginationInformation;
 import com.triplem.momoim.core.domain.review.Review;
 import com.triplem.momoim.core.domain.review.ReviewDetail;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,45 +38,48 @@ public class ReviewController {
     @Operation(operationId = "모임 리뷰 조회", summary = "모임 리뷰 조회", tags = {"reviews"}, description = "모임 리뷰 조회")
     public ApiResponse<List<ReviewDetail>> gatherReview(
         @PathVariable Long gatheringId,
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "페이징 offset") @RequestParam int offset,
         @Parameter(name = "페이징 limit") @RequestParam int limit) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         return ApiResponse.success(reviewService.getReviews(gatheringId, userId, new PaginationInformation(offset, limit)));
     }
 
     @PostMapping
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 리뷰 작성", summary = "모임 리뷰 작성", tags = {"reviews"}, description = "모임 리뷰 작성")
     public ApiResponse<Review> registerReview(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @RequestBody RegisterReviewRequest request) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         Review review = reviewService.register(request.toModel(userId));
         return ApiResponse.success(review);
     }
 
     @PatchMapping("/{reviewId}")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 리뷰 수정", summary = "모임 리뷰 수정", tags = {"reviews"}, description = "모임 리뷰 수정")
     public DefaultApiResponse modifyReview(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "reviewId", description = "수정 할 리뷰 ID") @PathVariable Long reviewId,
         @RequestBody ModifyReviewRequest request) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         reviewService.modify(request.toModel(reviewId, userId));
         return DefaultApiResponse.success();
     }
 
     @DeleteMapping("/{reviewId}")
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공")
     })
     @Operation(operationId = "모임 리뷰 삭제", summary = "모임 리뷰 삭제", tags = {"reviews"}, description = "모임 리뷰 삭제")
     public DefaultApiResponse deleteReview(
-        @Parameter(name = "userId", description = "인증 설계 완료 전까지 임시로 사용하는 userId") @RequestParam Long userId,
         @Parameter(name = "reviewId", description = "삭제 할 리뷰 ID") @PathVariable Long reviewId) {
+        Long userId = SecurityUtil.getMemberIdByPrincipal();
         reviewService.delete(userId, reviewId);
         return DefaultApiResponse.success();
     }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/config/SecurityConfig.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/config/SecurityConfig.java
@@ -3,10 +3,7 @@ package com.triplem.momoim.config;
 import com.triplem.momoim.auth.config.JwtAuthenticationEntryPoint;
 import com.triplem.momoim.auth.config.filter.JwtFilter;
 import com.triplem.momoim.auth.config.handler.CustomAccessDeniedHandler;
-import com.triplem.momoim.auth.jwt.JwtProvider;
 import com.triplem.momoim.auth.jwt.JwtResolver;
-import com.triplem.momoim.auth.utils.StaticEndpointChecker;
-import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -42,11 +39,8 @@ public class SecurityConfig {
         "/api/v1/token/**",
         "/**"
     };
-
-    private final StaticEndpointChecker endpointChecker;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
-    private final JwtProvider jwtProvider;
     private final JwtResolver jwtResolver;
     private final CorsConfigurationSource corsConfigurationSource;
 
@@ -65,13 +59,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint) // 인증 실패 예외 처리
                 .accessDeniedHandler(customAccessDeniedHandler) // 권한 없음 예외 처리
             )
-            .addFilterBefore(new JwtFilter(jwtProvider, jwtResolver, endpointChecker, List.of(
-                "/swagger-ui/**",
-                "/api-docs/**",
-                "/api/v1/token/**",
-                "/**"
-            )
-            ), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new JwtFilter(jwtResolver), UsernamePasswordAuthenticationFilter.class)
             .build();
     }
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- [x] FEAT : 새로운 기능 추가 및 개선

## 설명

### 이슈 번호
resolve #32 

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

### Key Changes

- 토큰이 없는 경우 GUEST 권한으로 설정
- API URL 화이트 리스트 인가 방식 제거

### How it Works

- 로그인 되지 않은 유저(토큰이 없는 경우)라면 기본적으로 GUEST로 인증 처리
- 토큰이 잘못 된 경우 Front 측에서 알아야 하므로 로그인 유도를 위한 Error Response 처리
- 로그인이 필요한 서비스인 경우 로그인 유도를 위해 PreAuthorize로 권한 검증을 통해 403 Response 처리

#### Work list
- [x] : Spring Security Jwt Filter 로직 수정
- [x] : 기존 컨트롤러 User ID 파라미터 제거

### To Reviewers

- JwtFilter 및 SpringSecurity에서 더 이상 사용되지 않는 필드들 제거 하였습니다.