### PR TITLE
모임 목록 조회 API 온/오프라인 구별 파라미터 추가

### DIFF
--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/gathering/dto/GatheringSearchOption.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/gathering/dto/GatheringSearchOption.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GatheringSearchOption {
     private List<Long> gatheringIds;
+    private Boolean isOffline;
     private String category;
     private String subCategory;
     private GatheringLocation gatheringLocation;
@@ -26,10 +27,11 @@ public class GatheringSearchOption {
     private SortOrder sortOrder;
 
     public static GatheringSearchOption of(
-        List<Long> gatheringIds, GatheringCategory category, GatheringSubCategory subCategory, GatheringLocation gatheringLocation,
+        List<Long> gatheringIds, Boolean isOffline, GatheringCategory category, GatheringSubCategory subCategory, GatheringLocation gatheringLocation,
         LocalDate gatheringDate, PaginationInformation paginationInformation, GatheringSortType sortType, SortOrder sortOrder) {
         return new GatheringSearchOption(
             gatheringIds,
+            isOffline,
             category != null ? category.name() : null,
             subCategory != null ? subCategory.name() : null,
             gatheringLocation,

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/gathering/infrastructure/GatheringEntity.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/gathering/infrastructure/GatheringEntity.java
@@ -64,8 +64,7 @@ public class GatheringEntity {
     @Column(length = 1000)
     @Convert(converter = GatheringTagConverter.class)
     private List<String> tags;
-
-    @Column(nullable = false)
+    
     @Enumerated(EnumType.STRING)
     private GatheringLocation location;
 

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/gathering/infrastructure/GatheringRepositoryImpl.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/gathering/infrastructure/GatheringRepositoryImpl.java
@@ -19,6 +19,7 @@ import com.triplem.momoim.core.domain.gathering.dto.GatheringPreview;
 import com.triplem.momoim.core.domain.gathering.dto.GatheringSearchOption;
 import com.triplem.momoim.core.domain.gathering.enums.GatheringSortType;
 import com.triplem.momoim.core.domain.gathering.enums.GatheringStatus;
+import com.triplem.momoim.core.domain.gathering.enums.GatheringType;
 import com.triplem.momoim.core.domain.gathering.model.Gathering;
 import com.triplem.momoim.core.domain.member.dto.GatheringMemberDetail;
 import com.triplem.momoim.core.domain.member.infrastructure.QGatheringMemberEntity;
@@ -175,6 +176,14 @@ public class GatheringRepositoryImpl implements GatheringRepository {
 
         if (searchOption.getGatheringIds() != null && !searchOption.getGatheringIds().isEmpty()) {
             builder.and(gatheringEntity.id.in(searchOption.getGatheringIds()));
+        }
+
+        if (searchOption.getIsOffline()) {
+            builder.and(gatheringEntity.gatheringType.eq(GatheringType.OFFLINE));
+        }
+
+        if (!searchOption.getIsOffline()) {
+            builder.and(gatheringEntity.gatheringType.ne(GatheringType.OFFLINE));
         }
 
         if (searchOption.getCategory() != null) {

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/gathering/controller/GatheringController.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/gathering/controller/GatheringController.java
@@ -38,6 +38,7 @@ public class GatheringController {
     @Operation(operationId = "모임 목록 조회", summary = "모임 목록 조회", tags = {"gatherings"}, description = "모임 목록 조회")
     @Parameters({
         @Parameter(name = "gatheringIds", description = "필터링 모임 id 목록", example = "1,2,3", schema = @Schema(implementation = Long[].class)),
+        @Parameter(name = "isOffline", description = "오프라인 모임 여부", schema = @Schema(implementation = Boolean.class)),
         @Parameter(name = "category", description = "필터링 카테고리", schema = @Schema(implementation = GatheringCategory.class)),
         @Parameter(name = "subCategory", description = "필터링 서브 카테고리", schema = @Schema(implementation = GatheringSubCategory.class)),
         @Parameter(name = "location", description = "필터링 지역", schema = @Schema(implementation = GatheringLocation.class)),

--- a/momoim-external-api/src/main/java/com/triplem/momoim/resolver/GatheringSearchOptionResolver.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/resolver/GatheringSearchOptionResolver.java
@@ -32,6 +32,7 @@ public class GatheringSearchOptionResolver implements HandlerMethodArgumentResol
         WebDataBinderFactory binderFactory) throws Exception {
         return GatheringSearchOption.of(
             getGatheringIds(webRequest),
+            getIsOffline(webRequest),
             getGatheringCategory(webRequest),
             getGatheringSubCategory(webRequest),
             getGatheringLocation(webRequest),
@@ -54,6 +55,16 @@ public class GatheringSearchOptionResolver implements HandlerMethodArgumentResol
         return Arrays.stream(ids)
             .map(Long::parseLong)
             .collect(Collectors.toList());
+    }
+
+    private Boolean getIsOffline(NativeWebRequest webRequest) {
+        String input = webRequest.getParameter("isOffline");
+
+        if (input == null) {
+            throw new BusinessException(ExceptionCode.BAD_REQUEST);
+        }
+
+        return Boolean.parseBoolean(input);
     }
 
     private GatheringCategory getGatheringCategory(NativeWebRequest webRequest) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- [x] FEAT : 새로운 기능 추가 및 개선

## 설명

### 이슈 번호
resolve #60

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

### Key Changes

- 모임 목록 조회 API에 온/오프라인 구별 파라미터를 추가하여 온라인 / 오프라인 모임을 구별하여 조회할 수 있습니다.