### PR TITLE
[MMM-78] SocialLogin 구현과 Auth에 대한 추가 API 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,16 @@ subprojects {
         mavenCentral()
     }
 
+//    ext {
+//        set('springCloudVersion', "2023.0.2")
+//    }
+//
+//    dependencyManagement {
+//        imports {
+//            mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+//        }
+//    }
+
     dependencies {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'

--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtProperties.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtProperties.java
@@ -11,20 +11,32 @@ public class JwtProperties {
 
     private final String accessTokenSecretKey;
     private final long accessTokenExpireTime;
+    private final String refreshTokenSecretKey;
+    private final long refreshTokenExpireTime;
 
     public JwtProperties(
             @Value("${jwt.access-token-secret-key}") String accessTokenSecretKey,
-            @Value("${jwt.access-token-expire-time}") long accessTokenExpireTime
+            @Value("${jwt.access-token-expire-time}") long accessTokenExpireTime,
+            @Value("${jwt.refresh-token-secret-key}") String refreshTokenSecretKey,
+            @Value("${jwt.refresh-token-expire-time}") long refreshTokenExpireTime
     ) {
         this.accessTokenSecretKey = accessTokenSecretKey;
         this.accessTokenExpireTime = accessTokenExpireTime;
+        this.refreshTokenSecretKey = refreshTokenSecretKey;
+        this.refreshTokenExpireTime = refreshTokenExpireTime;
     }
 
-    protected SecretKey getSecretKey() {
+    protected SecretKey getAccessTokenSecretKey() {
         return Keys.hmacShaKeyFor(accessTokenSecretKey.getBytes());
+    }
+    protected SecretKey getRefreshTokenSecretKey() {
+        return Keys.hmacShaKeyFor(refreshTokenSecretKey.getBytes());
     }
 
     protected long getAccessTokenExpireTime() {
         return accessTokenExpireTime;
+    }
+    protected long getRefreshTokenExpireTime() {
+        return refreshTokenExpireTime;
     }
 }

--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtProvider.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtProvider.java
@@ -15,10 +15,15 @@ public class JwtProvider {
 
     public TokenInfo generateAccessToken(User user) {
         long accessTokenExpireTime = jwtProperties.getAccessTokenExpireTime();
-        return generateToken(user, accessTokenExpireTime, JwtType.ACCESS_TOKEN);
+        return generateAccessTokenToken(user, accessTokenExpireTime, JwtType.ACCESS_TOKEN);
     }
 
-    private TokenInfo generateToken(User user, long expirationMillis, JwtType jwtType) {
+    public TokenInfo generateRefreshToken(User user) {
+        long refreshTokenExpireTime = jwtProperties.getRefreshTokenExpireTime();
+        return generateRefreshTokenToken(user, refreshTokenExpireTime, JwtType.REFRESH_TOKEN);
+    }
+
+    private TokenInfo generateAccessTokenToken(User user, long expirationMillis, JwtType jwtType) {
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + expirationMillis);
 
@@ -26,11 +31,25 @@ public class JwtProvider {
                 .setSubject(user.getId().toString())
                 .setIssuedAt(now)
                 .setExpiration(expiredDate)
-                .signWith(jwtProperties.getSecretKey(), SignatureAlgorithm.HS512)
+                .signWith(jwtProperties.getAccessTokenSecretKey(), SignatureAlgorithm.HS512)
                 .claim(JwtProperties.TOKEN_TYPE, jwtType.name())
                 .compact();
 
         return TokenInfo.of(accessToken, expiredDate);
+    }
 
+    private TokenInfo generateRefreshTokenToken(User user, long expirationMillis, JwtType jwtType) {
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + expirationMillis);
+
+        String accessToken = Jwts.builder()
+                .setSubject(user.getId().toString())
+                .setIssuedAt(now)
+                .setExpiration(expiredDate)
+                .signWith(jwtProperties.getAccessTokenSecretKey(), SignatureAlgorithm.HS512)
+                .claim(JwtProperties.TOKEN_TYPE, jwtType.name())
+                .compact();
+
+        return TokenInfo.of(accessToken, expiredDate);
     }
 }

--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtProvider.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtProvider.java
@@ -42,14 +42,14 @@ public class JwtProvider {
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + expirationMillis);
 
-        String accessToken = Jwts.builder()
+        String refreshToken = Jwts.builder()
                 .setSubject(user.getId().toString())
                 .setIssuedAt(now)
                 .setExpiration(expiredDate)
-                .signWith(jwtProperties.getAccessTokenSecretKey(), SignatureAlgorithm.HS512)
+                .signWith(jwtProperties.getRefreshTokenSecretKey(), SignatureAlgorithm.HS512)
                 .claim(JwtProperties.TOKEN_TYPE, jwtType.name())
                 .compact();
 
-        return TokenInfo.of(accessToken, expiredDate);
+        return TokenInfo.of(refreshToken, expiredDate);
     }
 }

--- a/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtResolver.java
+++ b/momoim-auth/src/main/java/com/triplem/momoim/auth/jwt/JwtResolver.java
@@ -16,8 +16,12 @@ public class JwtResolver {
     private final JwtProperties jwtProperties;
 
     public AuthUser resolveAccessToken(String token) {
-        return resolveToken(token);
+        return resolveAuthUserFromAccessToken(token);
     }
+    public AuthUser resolveRefreshToken(String token) {
+        return resolveAuthUserFromRefreshToken(token);
+    }
+
 
     /**
      * Internal method to parse and validate a JWT token. This method validates the token signature, structure, and expiration, and extracts claims to
@@ -28,13 +32,31 @@ public class JwtResolver {
      * @throws RuntimeException for various JWT parsing and validation errors
      * @apiNote Replace RuntimeException with CustomException and a well-defined ErrorCode enum for better error categorization and handling.
      */
-    private AuthUser resolveToken(String token) {
+    private AuthUser resolveAuthUserFromAccessToken(String token) {
         try {
             Claims claims = Jwts.parserBuilder()
-                .setSigningKey(jwtProperties.getSecretKey())
+                .setSigningKey(jwtProperties.getAccessTokenSecretKey())
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+
+            Long userId = Long.valueOf(claims.getSubject());
+            return AuthUser.from(userId);
+
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ExceptionCode.EXPIRED_JWT);
+        } catch (JwtException e) {
+            throw new BusinessException(ExceptionCode.UNKNOWN_JWT_VALIDATE_ERROR);
+        }
+    }
+
+    private AuthUser resolveAuthUserFromRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(jwtProperties.getRefreshTokenSecretKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
 
             Long userId = Long.valueOf(claims.getSubject());
             return AuthUser.from(userId);

--- a/momoim-auth/src/test/java/com/triplem/momoim/auth/jwt/JwtFixture.java
+++ b/momoim-auth/src/test/java/com/triplem/momoim/auth/jwt/JwtFixture.java
@@ -4,30 +4,45 @@ package com.triplem.momoim.auth.jwt;
 public class JwtFixture {
 
     private static final String ACCESS_TOKEN_SECRET_KEY = "ArACpIW3Yf2+VgWHZdButiZrYy6+VZnsL2/AGj8fVyDxQwL8Y7v4QEzs4BZrk49mWnwHS2WPuF8DP83+Sjk3OA==";
+    private static final String REFRESH_TOKEN_SECRET_KEY = "ArACpIW3Yf2+VgWHZdButiZrYy6+VZnsL2/AGj8fVyDxQwL8Y7v4QEzs4BZrk49mWnwHS2WPuF8DP83+Sjk3OA==";
+
     private static final String INVALID_ACCESS_TOKEN_SECRET_KEY = "ArACpIW3Yf2+VgWHZdButiZrYy6+VZnsL2/AGj8fVyDxQwL8Y7v4QEzs4BZrk49mWnwHS2WPuF8DP83+Sjk3OA=!";
+    private static final String INVALID_REFRESH_TOKEN_SECRET_KEY = "ArACpIW3Yf2+VgWHZdButiZrYy6+VZnsL2/AGj8fVyDxQwL8Y7v4QEzs4BZrk49mWnwHS2WPuF8DP83+Sjk3OA=!";
+
     private static final Long ACCESS_TOKEN_EXPIRE_TIME = 1800000L;  // 30 minutes
+    private static final Long REFRESH_TOKEN_EXPIRE_TIME = 3600000L;  // 1 hour
 
     public static JwtProvider JWT_PROVIDER() {
-        return new JwtProvider(createJwtProperties(ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME));
+        return new JwtProvider(createJwtProperties(ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     public static JwtResolver JWT_RESOLVER() {
-        return new JwtResolver(createJwtProperties(ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME));
+        return new JwtResolver(createJwtProperties(ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     public static JwtProvider JWT_PROVIDER_WITH_INVALID_SECRET_KEY() {
-        return new JwtProvider(createJwtProperties(INVALID_ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME));
+        return new JwtProvider(createJwtProperties(INVALID_ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_TIME, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     public static JwtProvider JWT_PROVIDER_WITH_EXPIRED_TOKEN() {
-        return new JwtProvider(createJwtProperties(INVALID_ACCESS_TOKEN_SECRET_KEY, -1000000L));
+        return new JwtProvider(createJwtProperties(INVALID_ACCESS_TOKEN_SECRET_KEY, -1000000L, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_TIME));
     }
 
     public static JwtResolver JWT_RESOLVER_WITH_EXPIRED_TOKEN() {
-        return new JwtResolver(createJwtProperties(INVALID_ACCESS_TOKEN_SECRET_KEY, -1000000L));
+        return new JwtResolver(createJwtProperties(INVALID_ACCESS_TOKEN_SECRET_KEY, -1000000L, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_TIME));
     }
 
-    private static JwtProperties createJwtProperties(String secretKey, Long expireTime) {
-        return new JwtProperties(secretKey, expireTime);
+    private static JwtProperties createJwtProperties(
+            String accessTokenSecretKey,
+            Long accessTokenExpireTime,
+            String refreshTokenSecretKey,
+            Long refreshTokenExpireTime
+    ) {
+        return new JwtProperties(
+                accessTokenSecretKey,
+                accessTokenExpireTime,
+                refreshTokenSecretKey,
+                refreshTokenExpireTime
+        );
     }
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/AccountType.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/AccountType.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum AccountType {
-    EMAIL(), KAKAO();
+    EMAIL(), KAKAO(), GOOGLE();
 
     AccountType() {
     }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/UserJpaRepository.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/UserJpaRepository.java
@@ -11,4 +11,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Boolean existsByEmail(String email);
 
     Boolean existsByName(String name);
+
+    Boolean existsByEmailAndAccountType(String email, AccountType accountType);
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/UserRepository.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/UserRepository.java
@@ -4,8 +4,10 @@ public interface UserRepository {
     User save(User user);
     User findById(Long id);
     User findUserByEmail(String email);
-
     void checkDuplicatedUserEmail(String email);
-
     void checkDuplicatedUserName(String name);
+    boolean existsByEmail(String email);
+    void checkDuplicatedUserEmailAndEmailAccountType(String email);
+    boolean existsByEmailAndGoogleAccountType(String email);
+    boolean existsByEmailAndKakaoAccountType(String email);
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/UserRepositoryImpl.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/UserRepositoryImpl.java
@@ -31,15 +31,37 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public void checkDuplicatedUserEmail(String email) {
-        if(userJpaRepository.existsByEmail(email)) {
+        if (userJpaRepository.existsByEmail(email)) {
             throw new BusinessException(ExceptionCode.INVALID_MEMBER_HAS_DUPLICATED_EMAIL);
         }
     }
 
     @Override
     public void checkDuplicatedUserName(String name) {
-        if(userJpaRepository.existsByName(name)) {
+        if (userJpaRepository.existsByName(name)) {
             throw new BusinessException(ExceptionCode.INVALID_MEMBER_HAS_DUPLICATED_NAME);
+        }
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userJpaRepository.existsByEmail(email);
+    }
+
+    @Override
+    public boolean existsByEmailAndGoogleAccountType(String email) {
+        return userJpaRepository.existsByEmailAndAccountType(email, AccountType.GOOGLE);
+    }
+
+    @Override
+    public boolean existsByEmailAndKakaoAccountType(String email) {
+        return userJpaRepository.existsByEmailAndAccountType(email, AccountType.KAKAO);
+    }
+
+    @Override
+    public void checkDuplicatedUserEmailAndEmailAccountType(String email) {
+        if (userJpaRepository.existsByEmailAndAccountType(email, AccountType.EMAIL)) {
+            throw new BusinessException(ExceptionCode.INVALID_MEMBER_HAS_DUPLICATED_EMAIL);
         }
     }
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshToken.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshToken.java
@@ -1,0 +1,18 @@
+package com.triplem.momoim.core.domain.user.auth;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+    private Long id;
+    private Long userId;
+    private String token;
+    private Date expiredAt;
+}

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenEntity.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenEntity.java
@@ -1,0 +1,46 @@
+package com.triplem.momoim.core.domain.user.auth;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String token;
+
+    private Date expiredAt;
+
+    public static RefreshTokenEntity from(RefreshToken refreshToken) {
+        return RefreshTokenEntity.builder()
+                .id(refreshToken.getId())
+                .userId(refreshToken.getUserId())
+                .token(refreshToken.getToken())
+                .expiredAt(refreshToken.getExpiredAt())
+                .build();
+    }
+
+    public RefreshToken toModel() {
+        return RefreshToken.builder()
+                .id(id)
+                .userId(userId)
+                .token(token)
+                .expiredAt(expiredAt)
+                .build();
+    }
+}

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenJpaRepository.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenJpaRepository.java
@@ -1,0 +1,6 @@
+package com.triplem.momoim.core.domain.user.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, Long> {
+}

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenJpaRepository.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenJpaRepository.java
@@ -2,5 +2,9 @@ package com.triplem.momoim.core.domain.user.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, Long> {
+    Optional<RefreshTokenEntity> findRefreshTokenByUserIdAndToken(Long userId, String token);
+
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepository.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.triplem.momoim.core.domain.user.auth;
+
+import com.triplem.momoim.core.domain.user.User;
+
+public interface RefreshTokenRepository {
+    RefreshToken save(RefreshToken refreshToken);
+}

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepository.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepository.java
@@ -1,7 +1,9 @@
 package com.triplem.momoim.core.domain.user.auth;
 
-import com.triplem.momoim.core.domain.user.User;
-
 public interface RefreshTokenRepository {
     RefreshToken save(RefreshToken refreshToken);
+
+    void delete(RefreshToken refreshToken);
+
+    RefreshToken findRefreshTokenByUserIdAndToken(Long userId, String token);
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepositoryImpl.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.triplem.momoim.core.domain.user.auth;
 
+import com.triplem.momoim.exception.BusinessException;
+import com.triplem.momoim.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,5 +14,17 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository{
     @Override
     public RefreshToken save(RefreshToken refreshToken) {
         return refreshTokenJpaRepository.save(RefreshTokenEntity.from(refreshToken)).toModel();
+    }
+
+    @Override
+    public void delete(RefreshToken refreshToken) {
+        refreshTokenJpaRepository.delete(RefreshTokenEntity.from(refreshToken));
+    }
+
+    @Override
+    public RefreshToken findRefreshTokenByUserIdAndToken(Long userId, String token) {
+        return refreshTokenJpaRepository.findRefreshTokenByUserIdAndToken(userId, token).orElseThrow(
+                () -> new BusinessException(ExceptionCode.NOT_FOUND_REFRESH_TOKEN)
+        ).toModel();
     }
 }

--- a/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepositoryImpl.java
+++ b/momoim-core/src/main/java/com/triplem/momoim/core/domain/user/auth/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,16 @@
+package com.triplem.momoim.core.domain.user.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository{
+
+    private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+
+    @Override
+    public RefreshToken save(RefreshToken refreshToken) {
+        return refreshTokenJpaRepository.save(RefreshTokenEntity.from(refreshToken)).toModel();
+    }
+}

--- a/momoim-external-api/build.gradle
+++ b/momoim-external-api/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
     implementation("org.springframework:spring-tx")
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
+    implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation "io.github.openfeign:feign-core:12.4"
 
     // Multi Module Implementation
     implementation(project(":momoim-auth"))

--- a/momoim-external-api/src/main/java/com/triplem/momoim/MomoimApplication.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/MomoimApplication.java
@@ -2,8 +2,10 @@ package com.triplem.momoim;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class MomoimApplication {
     public static void main(String[] args) {
         SpringApplication.run(MomoimApplication.class, args);

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/GoogleClient.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/GoogleClient.java
@@ -1,0 +1,27 @@
+package com.triplem.momoim.api.auth.client;
+
+import com.triplem.momoim.api.auth.client.dto.google.GoogleInfo;
+import com.triplem.momoim.api.auth.client.dto.google.GoogleToken;
+import com.triplem.momoim.api.auth.client.dto.kakao.KakaoInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.net.URI;
+
+@FeignClient(name = "GoogleClient")
+public interface GoogleClient {
+
+    @GetMapping
+    GoogleInfo getProfile(URI baseUrl, @RequestHeader("Authorization") String accessToken);
+
+    @PostMapping
+    GoogleToken getToken(URI baseUrl, @RequestParam("client_id") String clientId,
+                         @RequestParam("client_secret") String clientSecretKey,
+                         @RequestParam("redirect_uri") String redirectUrl,
+                         @RequestParam("code") String code,
+                         @RequestParam("grant_type") String grantType);
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/GoogleClient.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/GoogleClient.java
@@ -2,9 +2,7 @@ package com.triplem.momoim.api.auth.client;
 
 import com.triplem.momoim.api.auth.client.dto.google.GoogleInfo;
 import com.triplem.momoim.api.auth.client.dto.google.GoogleToken;
-import com.triplem.momoim.api.auth.client.dto.kakao.KakaoInfo;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/KakaoClient.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/KakaoClient.java
@@ -1,0 +1,23 @@
+package com.triplem.momoim.api.auth.client;
+
+import com.triplem.momoim.api.auth.client.dto.kakao.KakaoInfo;
+import com.triplem.momoim.api.auth.client.dto.kakao.KakaoToken;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.net.URI;
+
+@FeignClient(name = "KakaoClient")
+public interface KakaoClient {
+
+    @PostMapping
+    KakaoInfo getProfile(URI baseUrl, @RequestHeader("Authorization") String accessToken);
+
+    @PostMapping
+    KakaoToken getToken(URI baseUrl, @RequestParam("client_id") String restAPIKey,
+                        @RequestParam("redirect_uri") String redirectUrl,
+                        @RequestParam("code") String code,
+                        @RequestParam("grant_type") String grantType);
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/google/GoogleInfo.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/google/GoogleInfo.java
@@ -1,0 +1,21 @@
+package com.triplem.momoim.api.auth.client.dto.google;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GoogleInfo {
+    private String id;
+    private String email;
+    private boolean verifiedEmail;
+    private String name;
+    private String givenName;
+    private String familyName;
+    private String picture;
+    private String locale;
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/google/GoogleToken.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/google/GoogleToken.java
@@ -1,0 +1,19 @@
+package com.triplem.momoim.api.auth.client.dto.google;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GoogleToken {
+    private String accessToken;
+    private String refreshToken;
+    private String scope;
+    private String tokenType;
+    private int expiresIn;
+
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/KakaoAccount.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/KakaoAccount.java
@@ -1,0 +1,15 @@
+package com.triplem.momoim.api.auth.client.dto.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoAccount {
+    private Profile profile;
+    private String email;
+    private String gender;
+    private String ageRange;
+    private String profileImageURL;
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/KakaoInfo.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/KakaoInfo.java
@@ -1,0 +1,43 @@
+package com.triplem.momoim.api.auth.client.dto.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoInfo implements SocialLogin{
+    private Long id;
+    private KakaoAccount kakaoAccount;
+
+    @Override
+    public String getNickName() {
+        return this.kakaoAccount.getProfile().getNickname();
+    }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getGender() {
+        return this.kakaoAccount.getGender();
+    }
+
+    @Override
+    public String getAgeRange() {
+        return this.kakaoAccount.getAgeRange();
+    }
+
+    @Override
+    public String getEmail() {
+        return this.kakaoAccount.getEmail();
+    }
+
+    @Override
+    public String getProfileImageUrl() {return this.kakaoAccount.getProfile().getProfileImageUrl();}
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/KakaoToken.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/KakaoToken.java
@@ -1,0 +1,23 @@
+package com.triplem.momoim.api.auth.client.dto.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoToken {
+    private String tokenType;
+    private String accessToken;
+    private String refreshToken;
+    private Long expiresIn;
+    private Long refreshTokenExpiresIn;
+
+    public KakaoToken(final String accessToken, final String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/Profile.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/Profile.java
@@ -1,0 +1,12 @@
+package com.triplem.momoim.api.auth.client.dto.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Profile {
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/SocialLogin.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/client/dto/kakao/SocialLogin.java
@@ -1,0 +1,10 @@
+package com.triplem.momoim.api.auth.client.dto.kakao;
+
+public interface SocialLogin {
+    String getNickName();
+    Long getId();
+    String getGender();
+    String getAgeRange();
+    String getEmail();
+    String getProfileImageUrl();
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/config/FeignConfig.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/config/FeignConfig.java
@@ -1,0 +1,15 @@
+package com.triplem.momoim.api.auth.config;
+
+import feign.Client;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+//@EnableFeignClients
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public Client feignClient() {
+        return new Client.Default(null, null);
+    }
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/controller/AuthController.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/controller/AuthController.java
@@ -1,10 +1,7 @@
 package com.triplem.momoim.api.auth.controller;
 
 import com.triplem.momoim.api.auth.request.*;
-import com.triplem.momoim.api.auth.response.CheckEmailNicknameResponse;
-import com.triplem.momoim.api.auth.response.SigninResponse;
-import com.triplem.momoim.api.auth.response.SignupResponse;
-import com.triplem.momoim.api.auth.response.UserDetailResponse;
+import com.triplem.momoim.api.auth.response.*;
 import com.triplem.momoim.api.auth.service.AuthCommandService;
 import com.triplem.momoim.api.auth.service.AuthQueryService;
 import com.triplem.momoim.api.auth.service.GoogleLoginCommandService;
@@ -15,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -108,5 +106,30 @@ public class AuthController {
     @Operation(operationId = "구글 로그인", summary = "구글 로그인", tags = {"auths"}, description = "구글 로그인")
     public ApiResponse<SigninResponse> googleLogin(@RequestParam("code") String code, HttpServletResponse response) throws URISyntaxException {
         return ApiResponse.success(googleLoginCommandService.googleLogin(code, response));
+    }
+
+    @PostMapping("/logout")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공",  content = @Content(schema = @Schema(implementation = LogoutResponse.class)))
+    })
+    @Operation(operationId = "로그아웃", summary = "로그아웃 API", tags = {"auths"}, description = "Cookie 안의 Refresh Token과 Database 안의 Refresh Token 제거")
+    public ApiResponse<LogoutResponse> logout(
+            @CookieValue("REFRESH_TOKEN") Cookie cookie,
+            HttpServletResponse response
+    ) {
+        return ApiResponse.success(authCommandService.logout(cookie, response));
+    }
+
+    @PostMapping("/refresh")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공",  content = @Content(schema = @Schema(implementation = SigninResponse.class)))
+    })
+    @Operation(operationId = "Access 토큰 재발급", summary = "Access 토큰 재발급 API", tags = {"auths"}, description = "만료된 Access Token 재발급 API")
+    public ApiResponse<SigninResponse> refreshAccessToken(
+            @CookieValue("REFRESH_TOKEN") Cookie cookie,
+            HttpServletResponse httpServletResponse
+    ) {
+        SigninResponse response = authCommandService.refreshAccessToken(cookie, httpServletResponse);
+        return ApiResponse.success(response);
     }
 }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/controller/AuthController.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import com.triplem.momoim.api.auth.response.SignupResponse;
 import com.triplem.momoim.api.auth.response.UserDetailResponse;
 import com.triplem.momoim.api.auth.service.AuthCommandService;
 import com.triplem.momoim.api.auth.service.AuthQueryService;
+import com.triplem.momoim.api.auth.service.GoogleLoginCommandService;
+import com.triplem.momoim.api.auth.service.KakaoLoginCommandService;
 import com.triplem.momoim.api.common.ApiResponse;
 import com.triplem.momoim.auth.utils.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +19,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URISyntaxException;
+
 
 @RestController
 @RequestMapping("/api/auths")
@@ -24,6 +28,8 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthCommandService authCommandService;
     private final AuthQueryService authQueryService;
+    private final KakaoLoginCommandService kakaoLoginCommandService;
+    private final GoogleLoginCommandService googleLoginCommandService;
 
     @PostMapping("/signup")
     @ApiResponses(value = {
@@ -84,5 +90,23 @@ public class AuthController {
     public ApiResponse<CheckEmailNicknameResponse> checkDuplicatedNickname(@RequestBody CheckNicknameRequest request) {
         CheckEmailNicknameResponse response = authQueryService.checkDuplicatedNickname(request.name());
         return ApiResponse.success(response);
+    }
+
+    @PostMapping("/kakao")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공",  content = @Content(schema = @Schema(implementation = SigninResponse.class)))
+    })
+    @Operation(operationId = "카카오 로그인", summary = "카카오 로그인", tags = {"auths"}, description = "카카오 로그인")
+    public ApiResponse<SigninResponse> kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) throws URISyntaxException {
+        return ApiResponse.success(kakaoLoginCommandService.kakaoLogin(code, response));
+    }
+
+    @PostMapping("/google")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청 성공",  content = @Content(schema = @Schema(implementation = SigninResponse.class)))
+    })
+    @Operation(operationId = "구글 로그인", summary = "구글 로그인", tags = {"auths"}, description = "구글 로그인")
+    public ApiResponse<SigninResponse> googleLogin(@RequestParam("code") String code, HttpServletResponse response) throws URISyntaxException {
+        return ApiResponse.success(googleLoginCommandService.googleLogin(code, response));
     }
 }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/response/LogoutResponse.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/response/LogoutResponse.java
@@ -1,0 +1,19 @@
+package com.triplem.momoim.api.auth.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "로그아웃 응답")
+public record LogoutResponse(
+        @Schema(description = "로그아웃 응답 메시지", example = "SUCCESS")
+        String message
+) {
+    private static final String SUCCESS_MESSAGE = "SUCCESS";
+
+    public static LogoutResponse createSuccessLogoutResponse() {
+        return LogoutResponse.builder()
+                .message(SUCCESS_MESSAGE)
+                .build();
+    }
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthCommandService.java
@@ -1,19 +1,22 @@
 package com.triplem.momoim.api.auth.service;
 
-import com.triplem.momoim.api.auth.request.SigninRequest;
 import com.triplem.momoim.api.auth.request.SignupRequest;
 import com.triplem.momoim.api.auth.request.UserProfileUpdateRequest;
 import com.triplem.momoim.api.auth.response.SigninResponse;
 import com.triplem.momoim.api.auth.response.SignupResponse;
 import com.triplem.momoim.api.auth.response.UserDetailResponse;
+import com.triplem.momoim.auth.jwt.JwtProvider;
+import com.triplem.momoim.auth.jwt.TokenInfo;
 import com.triplem.momoim.core.domain.user.*;
 import com.triplem.momoim.exception.BusinessException;
 import com.triplem.momoim.exception.ExceptionCode;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Transactional
@@ -26,6 +29,8 @@ public class AuthCommandService {
     private final UserInterestCategoryRepository userInterestCategoryRepository;
     private final UserActiveLocationRepository userActiveLocationRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final TokenCommandService tokenCommandService;
 
     public SignupResponse signup(SignupRequest request) {
         userRepository.checkDuplicatedUserEmail(request.email());
@@ -54,5 +59,66 @@ public class AuthCommandService {
         List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(savedUser.getId());
 
         return UserDetailResponse.from(savedUser, userActiveLocations, userInterestCategories);
+    }
+
+    public SigninResponse socialLogin(
+            String email,
+            String name,
+            String profileImageUrl,
+            AccountType accountType,
+            HttpServletResponse response)
+    {
+        checkDuplicatedEmail(email, accountType);
+
+        if (userRepository.existsByEmailAndGoogleAccountType(email)) {
+            return getSigninResponseFromUser(email, response);
+        }
+
+        if (userRepository.existsByEmailAndKakaoAccountType(email)) {
+            return getSigninResponseFromUser(email, response);
+        }
+
+        User user = User.builder()
+                .email(email)
+                .name(name)
+                .accountType(accountType)
+                .profileImage(profileImageUrl)
+                .createdAt(LocalDateTime.now())
+                .build();
+        User savedUser = userRepository.save(user);
+        userInterestCategoryRegister.register(savedUser.getId(), List.of("ALL"));
+        userActiveLocationRegister.register(savedUser.getId(), List.of("ALL"));
+
+        TokenInfo tokenInfo = jwtProvider.generateAccessToken(savedUser);
+        tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
+
+        List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(savedUser.getId());
+        List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(savedUser.getId());
+
+        return SigninResponse.from(user, tokenInfo, userActiveLocations, userInterestCategories);
+    }
+
+    private void checkDuplicatedEmail(String email, AccountType accountType) {
+        userRepository.checkDuplicatedUserEmailAndEmailAccountType(email);
+
+        if (userRepository.existsByEmailAndGoogleAccountType(email) && accountType.equals(AccountType.KAKAO)) {
+            throw new BusinessException(ExceptionCode.INVALID_MEMBER_HAS_DUPLICATED_EMAIL);
+        }
+
+        if (userRepository.existsByEmailAndKakaoAccountType(email) && accountType.equals(AccountType.GOOGLE)) {
+            throw new BusinessException(ExceptionCode.INVALID_MEMBER_HAS_DUPLICATED_EMAIL);
+        }
+    }
+
+    private SigninResponse getSigninResponseFromUser(String email, HttpServletResponse response) {
+        User findedUser = userRepository.findUserByEmail(email);
+
+        TokenInfo tokenInfo = jwtProvider.generateAccessToken(findedUser);
+        tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
+
+        List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(findedUser.getId());
+        List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(findedUser.getId());
+
+        return SigninResponse.from(findedUser, tokenInfo, userActiveLocations, userInterestCategories);
     }
 }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthCommandService.java
@@ -91,6 +91,7 @@ public class AuthCommandService {
 
         TokenInfo tokenInfo = jwtProvider.generateAccessToken(savedUser);
         tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(savedUser.getId(), tokenInfo, response);
 
         List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(savedUser.getId());
         List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(savedUser.getId());
@@ -115,6 +116,7 @@ public class AuthCommandService {
 
         TokenInfo tokenInfo = jwtProvider.generateAccessToken(findedUser);
         tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(findedUser.getId(), tokenInfo, response);
 
         List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(findedUser.getId());
         List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(findedUser.getId());

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthCommandService.java
@@ -2,16 +2,22 @@ package com.triplem.momoim.api.auth.service;
 
 import com.triplem.momoim.api.auth.request.SignupRequest;
 import com.triplem.momoim.api.auth.request.UserProfileUpdateRequest;
+import com.triplem.momoim.api.auth.response.LogoutResponse;
 import com.triplem.momoim.api.auth.response.SigninResponse;
 import com.triplem.momoim.api.auth.response.SignupResponse;
 import com.triplem.momoim.api.auth.response.UserDetailResponse;
+import com.triplem.momoim.auth.AuthUser;
 import com.triplem.momoim.auth.jwt.JwtProvider;
+import com.triplem.momoim.auth.jwt.JwtResolver;
 import com.triplem.momoim.auth.jwt.TokenInfo;
 import com.triplem.momoim.core.domain.user.*;
+import com.triplem.momoim.core.domain.user.auth.RefreshToken;
 import com.triplem.momoim.exception.BusinessException;
 import com.triplem.momoim.exception.ExceptionCode;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Transactional
 @Service
 @RequiredArgsConstructor
@@ -30,7 +37,9 @@ public class AuthCommandService {
     private final UserActiveLocationRepository userActiveLocationRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final JwtResolver jwtResolver;
     private final TokenCommandService tokenCommandService;
+    private final TokenQueryService tokenQueryService;
 
     public SignupResponse signup(SignupRequest request) {
         userRepository.checkDuplicatedUserEmail(request.email());
@@ -61,6 +70,38 @@ public class AuthCommandService {
         return UserDetailResponse.from(savedUser, userActiveLocations, userInterestCategories);
     }
 
+    public LogoutResponse logout(Cookie cookie, HttpServletResponse response) {
+        String refreshTokenInCookie = cookie.getValue();
+
+        AuthUser authUser = jwtResolver.resolveRefreshToken(refreshTokenInCookie);
+        RefreshToken refreshTokenInDatabase = tokenQueryService.getByUserIdAndToken(authUser.id(), refreshTokenInCookie);
+        tokenCommandService.delete(refreshTokenInDatabase);
+        tokenCommandService.removeRefreshTokenInCookie(response, cookie);
+
+        return LogoutResponse.createSuccessLogoutResponse();
+    }
+
+    public SigninResponse refreshAccessToken(Cookie cookie, HttpServletResponse response) {
+        String refreshTokenInCookie = cookie.getValue();
+        AuthUser authUser = jwtResolver.resolveRefreshToken(refreshTokenInCookie);
+
+        RefreshToken refreshTokenInDatabase = tokenQueryService.getByUserIdAndToken(authUser.id(), refreshTokenInCookie);
+        User user = userRepository.findById(refreshTokenInDatabase.getUserId());
+        tokenCommandService.delete(refreshTokenInDatabase);
+
+        TokenInfo accessTokenInfo = jwtProvider.generateAccessToken(user);
+        TokenInfo refreshTokenInfo = jwtProvider.generateRefreshToken(user);
+
+        List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(user.getId());
+        List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(user.getId());
+
+        // set cookie
+//        tokenCommandService.storeAccessTokenInCookie(accessTokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(user.getId(), refreshTokenInfo, response);
+
+        return SigninResponse.from(user, accessTokenInfo, userActiveLocations, userInterestCategories);
+    }
+
     public SigninResponse socialLogin(
             String email,
             String name,
@@ -89,14 +130,16 @@ public class AuthCommandService {
         userInterestCategoryRegister.register(savedUser.getId(), List.of("ALL"));
         userActiveLocationRegister.register(savedUser.getId(), List.of("ALL"));
 
-        TokenInfo tokenInfo = jwtProvider.generateAccessToken(savedUser);
-        tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
-        tokenCommandService.storeRefreshTokenInCookie(savedUser.getId(), tokenInfo, response);
+        TokenInfo accessTokenInfo = jwtProvider.generateAccessToken(savedUser);
+        TokenInfo refreshTokenInfo = jwtProvider.generateRefreshToken(savedUser);
+
+//        tokenCommandService.storeAccessTokenInCookie(accessTokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(savedUser.getId(), refreshTokenInfo, response);
 
         List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(savedUser.getId());
         List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(savedUser.getId());
 
-        return SigninResponse.from(user, tokenInfo, userActiveLocations, userInterestCategories);
+        return SigninResponse.from(user, accessTokenInfo, userActiveLocations, userInterestCategories);
     }
 
     private void checkDuplicatedEmail(String email, AccountType accountType) {
@@ -114,13 +157,15 @@ public class AuthCommandService {
     private SigninResponse getSigninResponseFromUser(String email, HttpServletResponse response) {
         User findedUser = userRepository.findUserByEmail(email);
 
-        TokenInfo tokenInfo = jwtProvider.generateAccessToken(findedUser);
-        tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
-        tokenCommandService.storeRefreshTokenInCookie(findedUser.getId(), tokenInfo, response);
+        TokenInfo accessTokenInfo = jwtProvider.generateAccessToken(findedUser);
+        TokenInfo refreshTokenInfo = jwtProvider.generateRefreshToken(findedUser);
+
+//        tokenCommandService.storeAccessTokenInCookie(accessTokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(findedUser.getId(), refreshTokenInfo, response);
 
         List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(findedUser.getId());
         List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(findedUser.getId());
 
-        return SigninResponse.from(findedUser, tokenInfo, userActiveLocations, userInterestCategories);
+        return SigninResponse.from(findedUser, accessTokenInfo, userActiveLocations, userInterestCategories);
     }
 }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthQueryService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthQueryService.java
@@ -42,6 +42,7 @@ public class AuthQueryService {
 
         // set cookie
         tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(user.getId(), tokenInfo, response);
 
         return SigninResponse.from(user, tokenInfo, userActiveLocations, userInterestCategories);
     }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthQueryService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/AuthQueryService.java
@@ -36,15 +36,17 @@ public class AuthQueryService {
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new BusinessException(ExceptionCode.INVALID_LOGIN);
         }
-        TokenInfo tokenInfo = jwtProvider.generateAccessToken(user);
+        TokenInfo accessTokenInfo = jwtProvider.generateAccessToken(user);
+        TokenInfo refreshTokenInfo = jwtProvider.generateRefreshToken(user);
+
         List<UserActiveLocation> userActiveLocations = userActiveLocationRepository.findAllByUserId(user.getId());
         List<UserInterestCategory> userInterestCategories = userInterestCategoryRepository.findAllByUserId(user.getId());
 
         // set cookie
-        tokenCommandService.storeAccessTokenInCookie(tokenInfo, response);
-        tokenCommandService.storeRefreshTokenInCookie(user.getId(), tokenInfo, response);
+//        tokenCommandService.storeAccessTokenInCookie(accessTokenInfo, response);
+        tokenCommandService.storeRefreshTokenInCookie(user.getId(), refreshTokenInfo, response);
 
-        return SigninResponse.from(user, tokenInfo, userActiveLocations, userInterestCategories);
+        return SigninResponse.from(user, accessTokenInfo, userActiveLocations, userInterestCategories);
     }
 
     public UserDetailResponse getUserProfile(Long userId) {

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/GoogleLoginCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/GoogleLoginCommandService.java
@@ -1,0 +1,64 @@
+package com.triplem.momoim.api.auth.service;
+
+import com.triplem.momoim.api.auth.client.GoogleClient;
+import com.triplem.momoim.api.auth.client.dto.google.GoogleInfo;
+import com.triplem.momoim.api.auth.client.dto.google.GoogleToken;
+import com.triplem.momoim.api.auth.response.SigninResponse;
+import com.triplem.momoim.core.domain.user.AccountType;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class GoogleLoginCommandService {
+    private static final String AUTHORIZATION_CODE = "authorization_code";
+    private static final String AUTH_URI = "https://oauth2.googleapis.com/token";
+    private static final String USER_PROFILE_URL = "https://www.googleapis.com/userinfo/v2/me";
+    private final GoogleClient googleClient;
+    private final AuthCommandService authCommandService;
+
+    @Value("${google.client-id}")
+    private String clientId;
+
+    @Value("${google.client-secret-key}")
+    private String clientSecretKey;
+
+    @Value("${google.redirect-uri}")
+    private String redirectUri;
+
+    public SigninResponse googleLogin(String code, HttpServletResponse response) throws URISyntaxException {
+        GoogleToken googleToken = getToken(code);
+
+        GoogleInfo info = googleClient.getProfile(
+                new URI(USER_PROFILE_URL),
+                googleToken.getTokenType() + " " + googleToken.getAccessToken()
+        );
+        return authCommandService.socialLogin(
+                info.getEmail(),
+                info.getName(),
+                info.getPicture(),
+                AccountType.GOOGLE,
+                response
+        );
+    }
+
+    private GoogleToken getToken(String code) throws URISyntaxException {
+        return googleClient.getToken(
+                new URI(AUTH_URI),
+                clientId,
+                clientSecretKey,
+                redirectUri,
+                code,
+                AUTHORIZATION_CODE
+        );
+    }
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/KakaoLoginCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/KakaoLoginCommandService.java
@@ -1,0 +1,56 @@
+package com.triplem.momoim.api.auth.service;
+
+import com.triplem.momoim.api.auth.client.KakaoClient;
+import com.triplem.momoim.api.auth.client.dto.kakao.KakaoInfo;
+import com.triplem.momoim.api.auth.client.dto.kakao.KakaoToken;
+import com.triplem.momoim.api.auth.response.SigninResponse;
+import com.triplem.momoim.core.domain.user.AccountType;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginCommandService {
+
+    private static final String AUTHORIZATION_CODE = "authorization_code";
+    private static final String AUTH_URI = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+    private final KakaoClient kakaoClient;
+    private final AuthCommandService authCommandService;
+
+    @Value("${kakao.rest-api-key}")
+    private String restAPIKey;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public SigninResponse kakaoLogin(String code, HttpServletResponse response) throws URISyntaxException{
+        KakaoToken kakaoToken = getToken(code);
+
+        KakaoInfo info = kakaoClient.getProfile(
+                new URI(USER_PROFILE_URL),
+                kakaoToken.getTokenType() + " " + kakaoToken.getAccessToken()
+        );
+        log.info("kakao {} {} {}", info.getEmail(), info.getNickName(), info.getProfileImageUrl());
+        return authCommandService.socialLogin(
+                info.getEmail(),
+                info.getNickName(),
+                info.getProfileImageUrl(),
+                AccountType.KAKAO,
+                response
+        );
+    }
+
+    private KakaoToken getToken(String code) throws URISyntaxException {
+        return kakaoClient.getToken(new URI(AUTH_URI), restAPIKey, redirectUri, code, AUTHORIZATION_CODE);
+    }
+}

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
@@ -1,6 +1,8 @@
 package com.triplem.momoim.api.auth.service;
 
 import com.triplem.momoim.auth.jwt.TokenInfo;
+import com.triplem.momoim.core.domain.user.auth.RefreshToken;
+import com.triplem.momoim.core.domain.user.auth.RefreshTokenRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +18,10 @@ public class TokenCommandService {
     private static final String REFRESH_TOKEN_KEY_IN_COOKIE = "REFRESH_TOKEN";
     private static final String COOKIE_KEY_IN_HEADER = "Set-Cookie";
     private static final String COOKIE_DEFAULT_PATH_ROOT = "/";
-    private static final int DEFAULT_COOKIE_AGE = 7200;
+    private static final int DEFAULT_ACCESS_TOKEN_COOKIE_AGE = 7200;
+    private static final int DEFAULT_REFRESH_TOKEN_COOKIE_AGE = 1209600;
+
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Value("${spring.cookie.domain}")
     private String cookieDomain;
@@ -26,17 +31,25 @@ public class TokenCommandService {
                 .path(COOKIE_DEFAULT_PATH_ROOT)
                 .domain(cookieDomain)
                 .httpOnly(true)
-                .maxAge(DEFAULT_COOKIE_AGE)
+                .maxAge(DEFAULT_ACCESS_TOKEN_COOKIE_AGE)
                 .build();
         response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
     }
 
-    public void storeRefreshTokenInCookie(TokenInfo tokenInfo, HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
+    public void storeRefreshTokenInCookie(Long userId, TokenInfo tokenInfo, HttpServletResponse response) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(userId)
+                .token(tokenInfo.getValue())
+                .expiredAt(tokenInfo.getExpiredTime())
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
                 .path(COOKIE_DEFAULT_PATH_ROOT)
                 .domain(cookieDomain)
                 .httpOnly(true)
-                .maxAge(DEFAULT_COOKIE_AGE)
+                .maxAge(DEFAULT_REFRESH_TOKEN_COOKIE_AGE)
                 .build();
         response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
     }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class TokenCommandService {
     private static final String ACCESS_TOKEN_KEY_IN_COOKIE = "ACCESS_TOKEN";
+    private static final String REFRESH_TOKEN_KEY_IN_COOKIE = "REFRESH_TOKEN";
     private static final String COOKIE_KEY_IN_HEADER = "Set-Cookie";
     private static final String COOKIE_DEFAULT_PATH_ROOT = "/";
     private static final int DEFAULT_COOKIE_AGE = 7200;
@@ -21,6 +22,16 @@ public class TokenCommandService {
     private String cookieDomain;
 
     public void storeAccessTokenInCookie(TokenInfo tokenInfo, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
+                .path(COOKIE_DEFAULT_PATH_ROOT)
+                .domain(cookieDomain)
+                .httpOnly(true)
+                .maxAge(DEFAULT_COOKIE_AGE)
+                .build();
+        response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
+    }
+
+    public void storeRefreshTokenInCookie(TokenInfo tokenInfo, HttpServletResponse response) {
         ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
                 .path(COOKIE_DEFAULT_PATH_ROOT)
                 .domain(cookieDomain)

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
@@ -3,6 +3,7 @@ package com.triplem.momoim.api.auth.service;
 import com.triplem.momoim.auth.jwt.TokenInfo;
 import com.triplem.momoim.core.domain.user.auth.RefreshToken;
 import com.triplem.momoim.core.domain.user.auth.RefreshTokenRepository;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,5 +53,16 @@ public class TokenCommandService {
                 .maxAge(DEFAULT_REFRESH_TOKEN_COOKIE_AGE)
                 .build();
         response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
+    }
+
+    public void delete(RefreshToken token) {
+        refreshTokenRepository.delete(token);
+    }
+
+    public void removeRefreshTokenInCookie(HttpServletResponse response, Cookie refreshToken) {
+        refreshToken.setMaxAge(0);
+        refreshToken.setDomain(cookieDomain);
+        refreshToken.setPath("/");
+        response.addCookie(refreshToken);
     }
 }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenQueryService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenQueryService.java
@@ -1,0 +1,18 @@
+package com.triplem.momoim.api.auth.service;
+
+import com.triplem.momoim.core.domain.user.auth.RefreshToken;
+import com.triplem.momoim.core.domain.user.auth.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TokenQueryService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken getByUserIdAndToken(Long userId, String token) {
+        return refreshTokenRepository.findRefreshTokenByUserIdAndToken(userId, token);
+    }
+}

--- a/momoim-infrastructure/build.gradle
+++ b/momoim-infrastructure/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     implementation 'org.springframework:spring-context'
-
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
     implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
 }

--- a/momoim-support/src/main/java/com/triplem/momoim/exception/ExceptionCode.java
+++ b/momoim-support/src/main/java/com/triplem/momoim/exception/ExceptionCode.java
@@ -20,6 +20,7 @@ public enum ExceptionCode {
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "EXPIRED_JWT", "만료된 토큰입니다."),
     INVALID_PRINCIPAL(HttpStatus.BAD_REQUEST, "INVALID_PRINCIPAL", "로그인 객체의 정보가 유효하지 않거나, 존재하지 않습니다."),
     INVALID_LOGIN(HttpStatus.BAD_REQUEST, "INVALID_LOGIN", "올바르지 않은 이메일 또는 비밀번호입니다."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "NOT_FOUND_REFRESH_TOKEN", "리프레시 토큰이 존재하지 않습니다."),
 
     // =============================================================
     // ==                         Member                          ==


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 이슈 번호
resolve #78 
<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

### Key Changes

- 소셜 로그인 기능 추가
  - Kakao Login
  - Google Login
- Logout API 정의
- Access token refresh API 정의

### How it Works
- 소셜로그인 시 이메일이 중복되어 가입되지 않도록 정책 정의
- Refresh Token 발급과 Cookie를 통해서 저장될 수 있도록 정의
  - Logout API와 Refresh API는 서버에서 책임을 가지고 로직 수행할 수 있도록 설정
- AccessToken을 Cookie로 저장하는 로직 제거

### To Reviewers

- 애매하거나 같이 얘기해보고 싶은 부분