### PR TITLE
[MMM-80] Profile 관심 카테고리 응답 포맷 변경

### DIFF
--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/response/SigninResponse.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/response/SigninResponse.java
@@ -45,7 +45,7 @@ public record SigninResponse(
                         .toList();
 
                 List<String> interestCategories = userInterestCategories.stream()
-                        .map(UserInterestCategory::getCategory)
+                        .map(UserInterestCategory::getSubCategory)
                         .toList();
 
                 return SigninResponse.builder()

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/response/UserDetailResponse.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/response/UserDetailResponse.java
@@ -31,7 +31,7 @@ public record UserDetailResponse(
         List<String> regions,
 
         @Schema(description = "관심 카테고리", example = "{'CULTURE': ['MOVIE', 'CONCERT'], 'FOOD': ['COOKING']]")
-        Map<String, List<String>> interestCategories
+        List<String> interestCategories
 ) {
         public static UserDetailResponse from(
                 User user,
@@ -42,20 +42,24 @@ public record UserDetailResponse(
                         .map(UserActiveLocation::getActiveLocationType)
                         .toList();
 
-                Set<String> allCategories = userInterestCategories.stream()
-                        .map(UserInterestCategory::getCategory)
-                        .collect(Collectors.toSet());
+                List<String> interestedCategories = userInterestCategories.stream()
+                        .map(UserInterestCategory::getSubCategory)
+                        .toList();
 
-                Map<String, List<String>> interestCategories = userInterestCategories.stream()
-                        .filter(interest -> interest.getSubCategory() != null && !interest.getSubCategory().isEmpty())
-                        .collect(Collectors.groupingBy(
-                                UserInterestCategory::getCategory,
-                                Collectors.mapping(UserInterestCategory::getSubCategory, Collectors.toList())
-                        ));
-
-                allCategories.forEach(category ->
-                        interestCategories.putIfAbsent(category, Collections.emptyList())
-                );
+//                Set<String> allCategories = userInterestCategories.stream()
+//                        .map(UserInterestCategory::getCategory)
+//                        .collect(Collectors.toSet());
+//
+//                Map<String, List<String>> interestCategories = userInterestCategories.stream()
+//                        .filter(interest -> interest.getSubCategory() != null && !interest.getSubCategory().isEmpty())
+//                        .collect(Collectors.groupingBy(
+//                                UserInterestCategory::getCategory,
+//                                Collectors.mapping(UserInterestCategory::getSubCategory, Collectors.toList())
+//                        ));
+//
+//                allCategories.forEach(category ->
+//                        interestCategories.putIfAbsent(category, Collections.emptyList())
+//                );
 
                 return UserDetailResponse.builder()
                         .email(user.getEmail())
@@ -63,7 +67,7 @@ public record UserDetailResponse(
                         .profileImage(user.getProfileImage())
                         .accountType(user.getAccountType().name())
                         .regions(regions)
-                        .interestCategories(interestCategories)
+                        .interestCategories(interestedCategories)
                         .build();
         }
 }

--- a/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
+++ b/momoim-external-api/src/main/java/com/triplem/momoim/api/auth/service/TokenCommandService.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -21,6 +23,7 @@ public class TokenCommandService {
     private static final String COOKIE_DEFAULT_PATH_ROOT = "/";
     private static final int DEFAULT_ACCESS_TOKEN_COOKIE_AGE = 7200;
     private static final int DEFAULT_REFRESH_TOKEN_COOKIE_AGE = 1209600;
+    private static final List<String> DEFAULT_COOKIE_DOMAINS = List.of("localhost", "momoim.co.kr");
 
     private final RefreshTokenRepository refreshTokenRepository;
 
@@ -28,13 +31,15 @@ public class TokenCommandService {
     private String cookieDomain;
 
     public void storeAccessTokenInCookie(TokenInfo tokenInfo, HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
-                .path(COOKIE_DEFAULT_PATH_ROOT)
-                .domain(cookieDomain)
-                .httpOnly(true)
-                .maxAge(DEFAULT_ACCESS_TOKEN_COOKIE_AGE)
-                .build();
-        response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
+        for (String domain : DEFAULT_COOKIE_DOMAINS) {
+            ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
+                    .path(COOKIE_DEFAULT_PATH_ROOT)
+                    .domain(domain)
+                    .httpOnly(true)
+                    .maxAge(DEFAULT_ACCESS_TOKEN_COOKIE_AGE)
+                    .build();
+            response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
+        }
     }
 
     public void storeRefreshTokenInCookie(Long userId, TokenInfo tokenInfo, HttpServletResponse response) {
@@ -46,13 +51,15 @@ public class TokenCommandService {
 
         refreshTokenRepository.save(refreshToken);
 
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
-                .path(COOKIE_DEFAULT_PATH_ROOT)
-                .domain(cookieDomain)
-                .httpOnly(true)
-                .maxAge(DEFAULT_REFRESH_TOKEN_COOKIE_AGE)
-                .build();
-        response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
+        for (String domain : DEFAULT_COOKIE_DOMAINS) {
+            ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_KEY_IN_COOKIE, tokenInfo.getValue())
+                    .path(COOKIE_DEFAULT_PATH_ROOT)
+                    .domain(domain)
+                    .httpOnly(true)
+                    .maxAge(DEFAULT_REFRESH_TOKEN_COOKIE_AGE)
+                    .build();
+            response.addHeader(COOKIE_KEY_IN_HEADER, cookie.toString());
+        }
     }
 
     public void delete(RefreshToken token) {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

<!-- 해당되는 사항만 남기고 나머지 줄을 삭제해주세요 -->

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

### 이슈 번호
resolve #80 

<!-- 키워드를 사용해 이슈를 연결해주세요 -->
<!-- 예시: close #1 / closes #1, #3 / resolve #4 -->

### Key Changes

- Profile 조회 API와 Signin API의 응답에서 관심카테고리의 응답을 서브카테고리의 리스트 형태로 반환하도록 변경
- Token을 쿠키에 저장할 시 localhost와 momoim.co.kr 2개의 값이 저장이 되도록 변경
